### PR TITLE
Implement support for Consent strings v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,28 @@ func main() {
 	// Patch an existing consent
 	c2.Vendors[999] = true
 	fmt.Println(c2.String())
+
+	// Decode a consent v2 string
+	cv2, err := consent.ParseV2("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA")
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Last modified: %s, vendors allowed: %v\n",
+		cv2.LastUpdated, cv2.VendorConsent)
+
+	// decode a consent string without knowing the version beforehand
+	cvx, err := consent.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
+	if err != nil {
+	fmt.Println(err)
+		os.Exit(1)
+	}
+	switch c3 := cvx.(type) {
+	case *consent.ConsentV1:
+		fmt.Printf("V1. PurposesAllowed: %v\n", c3.PurposesAllowed)
+	case *consent.ConsentV2:
+		fmt.Printf("V2. PurposesConsent: %v\n", c3.PurposesConsent)
+	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimalistic Go library to encode and decode [IAB consent][iab] strings.
 
 ### Usage examples
 
-## Version 1
+#### Version 1
 
 ```go
 package main
@@ -51,7 +51,7 @@ func main() {
 }
 ```
 
-## Version 2
+### Version 2
 
 ```go
 	// Decode a consent v2 string
@@ -65,7 +65,7 @@ func main() {
 		cv2.LastUpdated, cv2.VendorConsent)
 ```
 
-## Consent string of unknown version
+### Consent string of unknown version
 
 ```go
 	// decode a consent string without knowing the version beforehand

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func main() {
 }
 ```
 
-### Version 2
+#### Version 2
 
 ```go
 	// Decode a consent v2 string
@@ -65,7 +65,7 @@ func main() {
 		cv2.LastUpdated, cv2.VendorConsent)
 ```
 
-### Consent string of unknown version
+#### Consent string of unknown version
 
 ```go
 	// decode a consent string without knowing the version beforehand

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A minimalistic Go library to encode and decode [IAB consent][iab] strings.
 
 [iab]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/68f5e0012a7bdb00867ce9fee57fb67cfe9153e3/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md
 
-### Usage example
+### Usage examples
+
+## Version 1
 
 ```go
 package main
@@ -46,7 +48,12 @@ func main() {
 	// Patch an existing consent
 	c2.Vendors[999] = true
 	fmt.Println(c2.String())
+}
+```
 
+## Version 2
+
+```go
 	// Decode a consent v2 string
 	cv2, err := consent.ParseV2("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA")
 
@@ -56,7 +63,11 @@ func main() {
 	}
 	fmt.Printf("Last modified: %s, vendors allowed: %v\n",
 		cv2.LastUpdated, cv2.VendorConsent)
+```
 
+## Consent string of unknown version
+
+```go
 	// decode a consent string without knowing the version beforehand
 	cvx, err := consent.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
 	if err != nil {
@@ -69,5 +80,4 @@ func main() {
 	case *consent.ConsentV2:
 		fmt.Printf("V2. PurposesConsent: %v\n", c3.PurposesConsent)
 	}
-}
 ```

--- a/bits.go
+++ b/bits.go
@@ -29,6 +29,14 @@ func (b *bitWriter) AppendBools(bools []bool) {
 	}
 }
 
+func (b *bitWriter) AppendBit(x bool) {
+	var v byte
+	if x {
+		v = 1
+	}
+	b.AppendByte(v, 1)
+}
+
 func (b *bitWriter) AppendBits(bits bitWriter) {
 	for i := range bits.data {
 		b.AppendByte(bits.data[i], 8)
@@ -105,4 +113,13 @@ func (b *bitReader) ReadInt(size uint) (int64, bool) {
 		out = out<<bitSize | int64(v)
 	}
 	return out, true
+}
+
+func (b *bitReader) ReadBit() (bool, bool) {
+	out := false
+	v, ok := b.ReadByte(1)
+	if v > 0 {
+		out = true
+	}
+	return out, ok
 }

--- a/bits.go
+++ b/bits.go
@@ -116,10 +116,6 @@ func (b *bitReader) ReadInt(size uint) (int64, bool) {
 }
 
 func (b *bitReader) ReadBit() (bool, bool) {
-	out := false
 	v, ok := b.ReadByte(1)
-	if v > 0 {
-		out = true
-	}
-	return out, ok
+	return v > 0, ok
 }

--- a/consent.go
+++ b/consent.go
@@ -1,320 +1,34 @@
 package consent
 
-import (
-	"encoding/base64"
-	"errors"
-	"strings"
-	"time"
-)
-
-type encodingType byte
-
-const (
-	bitFieldType encodingType = 0
-	rangeType    encodingType = 1
-)
-
-var (
-	// ErrUnexpectedEnd is returned when a consent string is too short
-	ErrUnexpectedEnd = errors.New("consent: unexpected end")
-
-	// ErrUnsupported is returned when a string version is not 1
-	ErrUnsupported = errors.New("consent: version is not supported")
-)
-
-// Consent is a golang representation of an IAB consent string
-//
-// Implementation is done as per IAB Consent String format v1.1:
-// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/68f5e0012a7bdb00867ce9fee57fb67cfe9153e3/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md
-type Consent struct {
-	Version           byte
-	Created           time.Time
-	LastUpdated       time.Time
-	CmpID             int
-	CmpVersion        int
-	ConsentScreen     byte
-	ConsentLanguage   string
-	VendorListVersion int
-	PurposesAllowed   [24]bool
-
-	MaxVendorID  int
-	encodingType encodingType
-
-	Vendors map[int]bool
+func ParseConsentVersion(s string) (byte, error) {
+	if len(s) == 0 {
+		return 0, ErrUnexpectedEnd
+	}
+	// string is base64-encoded and version is encoded in the first 6 bits (i.e. first char in b64 string)
+	switch s[0] {
+	case 'B':
+		return 1, nil
+	case 'C':
+		return 2, nil
+	}
+	return 0, ErrUnsupported
 }
 
-// New creates a new instance of a Consent struct
-func New(cmpID, cmpVersion int, consentScreen byte, lang string, vendorListVerson int, purposesAllowed [24]bool, allowedVendors map[int]bool) Consent {
-
-	vendors := make(map[int]bool)
-	for k, v := range allowedVendors {
-		vendors[k] = v
-	}
-
-	return Consent{
-		Version:           1,
-		Created:           time.Now(),
-		LastUpdated:       time.Now(),
-		CmpID:             cmpID,
-		CmpVersion:        cmpVersion,
-		ConsentScreen:     consentScreen,
-		ConsentLanguage:   lang,
-		VendorListVersion: vendorListVerson,
-		PurposesAllowed:   purposesAllowed,
-		Vendors:           vendors,
-	}
+type Consent interface {
+	Version() byte
+	String() string
 }
 
-// Bytes returns raw, i.e. not base64 encoded, consent string bytes
-func (c *Consent) Bytes() []byte {
-	var b bitWriter
-	b.AppendByte(c.Version, 6)
-	b.AppendInt(c.Created.UnixNano()/int64(time.Second/10), 36)
-	b.AppendInt(c.LastUpdated.UnixNano()/int64(time.Second/10), 36)
-	b.AppendInt(int64(c.CmpID), 12)
-	b.AppendInt(int64(c.CmpVersion), 12)
-	b.AppendByte(c.ConsentScreen, 6)
-	lang := []byte(strings.ToUpper(c.ConsentLanguage))
-	if len(lang) == 2 {
-		b.AppendByte(lang[0]-byte('A'), 6)
-		b.AppendByte(lang[1]-byte('A'), 6)
-	} else {
-		b.AppendByte(byte('X')-byte('A'), 6)
-		b.AppendByte(byte('X')-byte('A'), 6)
-	}
-	b.AppendInt(int64(c.VendorListVersion), 12)
-	b.AppendBools(c.PurposesAllowed[:])
-	b.AppendInt(int64(c.MaxVendorID), 16)
-
-	switch ecType, defConsent, rngCount := c.findSmallest(); ecType {
-	case bitFieldType:
-		b.AppendByte(byte(bitFieldType), 1) // encoding type
-		for i := 1; i <= c.MaxVendorID; i++ {
-			var v byte
-			if c.Vendors[i] {
-				v = 1
-			}
-			b.AppendByte(v, 1)
-		}
-	case rangeType:
-		b.AppendByte(byte(rangeType), 1) // encoding type
-		if defConsent {
-			b.AppendByte(1, 1)
-		} else {
-			b.AppendByte(0, 1)
-		}
-
-		b.AppendInt(rngCount, 12)
-		for i := 1; i <= c.MaxVendorID; i++ {
-			start := i
-			for ; start <= c.MaxVendorID && c.Vendors[start] == defConsent; start++ {
-			}
-			end := start
-			for ; end <= c.MaxVendorID && c.Vendors[end] != defConsent; end++ {
-			}
-
-			if end == start {
-				break
-			} else if end-start == 1 {
-				b.AppendByte(0, 1)
-				b.AppendInt(int64(start), 16)
-			} else {
-				b.AppendByte(1, 1)
-				b.AppendInt(int64(start), 16)
-				b.AppendInt(int64(end-1), 16)
-			}
-			i = end
-		}
-	}
-
-	return b.Bytes()
-}
-
-func (c *Consent) findSmallest() (encodingType, bool, int64) {
-	var bfScore, rtScore, rfScore int
-	// bitfield, range with default consent == true, and range with false
-	var rtRecords, rfRecords int64
-
-	bfScore = c.MaxVendorID
-	rtScore = 1 + 12
-	rfScore = 1 + 12
-
-	for i := 1; i <= c.MaxVendorID; i++ {
-		cur := c.Vendors[i]
-		start := i
-		for ; i <= c.MaxVendorID && c.Vendors[i] == cur; i++ {
-		}
-		end := i
-		i--
-
-		size := 1
-		if end-start == 1 {
-			size += 16
-		} else {
-			size += 16 + 16
-		}
-
-		if cur {
-			rfScore += size
-			rfRecords++
-		} else {
-			rtScore += size
-			rtRecords++
-		}
-	}
-
-	min := bfScore
-	if min > rtScore {
-		min = rtScore
-	}
-	if min > rfScore {
-		min = rfScore
-	}
-
-	if min == rfScore {
-		return rangeType, false, rfRecords
-	} else if min == rtScore {
-		return rangeType, true, rtRecords
-	} else {
-		return bitFieldType, false, 0
-	}
-}
-
-func (c *Consent) outputRange(defConsent bool) (int64, bitWriter) {
-	var b bitWriter
-	var count int64
-	return count, b
-}
-
-// String return a base64-encoded consent string
-func (c *Consent) String() string {
-	return base64.RawURLEncoding.EncodeToString(c.Bytes())
-}
-
-// ParseRaw converts a raw, i.e. non base64-encoded, consent string into the
-// Consent struct
-func (c *Consent) ParseRaw(binary []byte) error {
-	if len(binary) < 21 {
-		return ErrUnexpectedEnd
-	}
-
-	b := newBitReader(binary)
-
-	c.Version, _ = b.ReadByte(6)
-	if c.Version != 1 {
-		return ErrUnsupported
-	}
-
-	dt, _ := b.ReadInt(36)
-	c.Created = time.Unix(dt/10, dt%10*100*1000*1000)
-
-	dt, _ = b.ReadInt(36)
-	c.LastUpdated = time.Unix(dt/10, dt%10*100*1000*1000)
-
-	dt, _ = b.ReadInt(12)
-	c.CmpID = int(dt)
-
-	dt, _ = b.ReadInt(12)
-	c.CmpVersion = int(dt)
-
-	c.ConsentScreen, _ = b.ReadByte(6)
-
-	l1, _ := b.ReadByte(6)
-	l2, _ := b.ReadByte(6)
-	c.ConsentLanguage = string([]byte{l1 + byte('A'), l2 + byte('A')})
-
-	dt, _ = b.ReadInt(12)
-	c.VendorListVersion = int(dt)
-
-	for i := range c.PurposesAllowed {
-		by, _ := b.ReadByte(1)
-		v := false
-		if by == 1 {
-			v = true
-		}
-		c.PurposesAllowed[i] = v
-	}
-
-	dt, _ = b.ReadInt(16)
-	c.MaxVendorID = int(dt)
-
-	by, _ := b.ReadByte(1)
-	c.encodingType = encodingType(by)
-	c.Vendors = make(map[int]bool)
-	switch c.encodingType {
-	case bitFieldType:
-		for i := 1; i <= c.MaxVendorID; i++ {
-			if by, ok := b.ReadByte(1); !ok {
-				return ErrUnexpectedEnd
-			} else if by == 1 {
-				c.Vendors[i] = true
-			}
-		}
-	case rangeType:
-		by, ok := b.ReadByte(1)
-		if !ok {
-			return ErrUnexpectedEnd
-		}
-		defCons := false
-		if by == 1 {
-			defCons = true
-
-			for i := 1; i <= int(c.MaxVendorID); i++ {
-				c.Vendors[i] = true
-			}
-		}
-
-		numEntries, ok := b.ReadInt(12)
-		if !ok {
-			return ErrUnexpectedEnd
-		}
-		for i := 0; i < int(numEntries); i++ {
-			singleOrRange, ok := b.ReadByte(1)
-			if !ok {
-				return ErrUnexpectedEnd
-			}
-			if singleOrRange == 0 { // Single
-				dt, ok = b.ReadInt(16)
-				if !ok {
-					return ErrUnexpectedEnd
-				}
-				c.Vendors[int(dt)] = !defCons
-			} else { // Range
-				start, ok := b.ReadInt(16)
-				if !ok {
-					return ErrUnexpectedEnd
-				}
-				end, ok := b.ReadInt(16)
-				if !ok {
-					return ErrUnexpectedEnd
-				}
-				for j := start; j <= end; j++ {
-					if defCons {
-						delete(c.Vendors, int(j))
-					} else {
-						c.Vendors[int(j)] = true
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-// Parse parses base64 encoded consent
-func (c *Consent) Parse(data string) error {
-	bytes := []byte(data)
-	bin := make([]byte, base64.RawStdEncoding.DecodedLen(len(bytes)))
-	_, err := base64.RawURLEncoding.Decode(bin, bytes)
+func Parse(s string) (Consent, error) {
+	v, err := ParseConsentVersion(s)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return c.ParseRaw(bin)
-}
-
-// Parse parses base64 encoded consent
-func Parse(data string) (*Consent, error) {
-	c := new(Consent)
-	return c, c.Parse(data)
+	switch v {
+	case 1:
+		return ParseV1(s)
+	case 2:
+		return ParseV2(s)
+	}
+	return nil, nil // unreachable
 }

--- a/consent_test.go
+++ b/consent_test.go
@@ -11,11 +11,11 @@ const (
 
 func TestParseVersion(t *testing.T) {
 	v, err := ParseConsentVersion(csv1)
-	equal(t, nil, err)
+	noError(t, err)
 	equal(t, byte(1), v)
 
 	v, err = ParseConsentVersion(csv2)
-	equal(t, nil, err)
+	noError(t, err)
 	equal(t, byte(2), v)
 
 	v, err = ParseConsentVersion("X32g")

--- a/consent_test.go
+++ b/consent_test.go
@@ -1,123 +1,45 @@
 package consent
 
 import (
-	"reflect"
 	"testing"
-	"time"
 )
 
-func noError(t *testing.T, err error) {
-	if err != nil {
-		t.Errorf("Got error: %s", err)
-	}
+const (
+	csv1 = "BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA"
+	csv2 = "COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA"
+)
+
+func TestParseVersion(t *testing.T) {
+	v, err := ParseConsentVersion(csv1)
+	equal(t, nil, err)
+	equal(t, byte(1), v)
+
+	v, err = ParseConsentVersion(csv2)
+	equal(t, nil, err)
+	equal(t, byte(2), v)
+
+	v, err = ParseConsentVersion("X32g")
+	equal(t, err, ErrUnsupported)
 }
 
-func equal(t *testing.T, expected, got interface{}) {
-	if !reflect.DeepEqual(expected, got) {
-		t.Errorf("Expected '%s', got '%s'", expected, got)
-	}
-}
-
-func TestConsentString_OfficialDocTest(t *testing.T) {
-	t2017, _ := time.Parse(time.RFC3339Nano, "2017-11-07T19:15:55.4Z")
-	c := Consent{
-		Version:           1,
-		Created:           t2017,
-		LastUpdated:       t2017,
-		CmpID:             7,
-		CmpVersion:        1,
-		ConsentScreen:     3,
-		ConsentLanguage:   "EN",
-		VendorListVersion: 8,
-		PurposesAllowed:   [24]bool{true, true, true, false},
-
-		MaxVendorID:  2011,
-		encodingType: rangeType,
-
-		Vendors: make(map[int]bool),
-	}
-	for i := 0; i < 2012; i++ {
-		c.Vendors[i] = true
-	}
-	delete(c.Vendors, 9)
-
-	equal(t, "BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA", c.String())
-}
-
-func TestConsentParse_OfficialDocTest(t *testing.T) {
-	var c Consent
-	t2017, _ := time.Parse(time.RFC3339Nano, "2017-11-07T19:15:55.4Z")
-	noError(t, c.Parse("BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA"))
-
-	if c.Version != 1 {
+func TestParseConsentString(t *testing.T) {
+	v, err := Parse(csv1)
+	equal(t, nil, err)
+	equal(t, byte(1), v.Version())
+	v1, ok := v.(*ConsentV1)
+	equal(t, ok, true)
+	if v1 == nil {
 		t.Fail()
 	}
-	if c.Created.UTC() != t2017 {
+	equal(t, "EN", v1.ConsentLanguage)
+
+	v, err = Parse(csv2)
+	equal(t, nil, err)
+	equal(t, byte(2), v.Version())
+	v2, ok := v.(*ConsentV2)
+	equal(t, ok, true)
+	if v2 == nil {
 		t.Fail()
 	}
-	if c.LastUpdated.UTC() != t2017 {
-		t.Fail()
-	}
-
-	equal(t, "EN", c.ConsentLanguage)
-	if [24]bool{true, true, true, false} != c.PurposesAllowed {
-		t.Fail()
-	}
-
-	vendors := make(map[int]bool)
-	for i := 1; i < 2012; i++ {
-		vendors[i] = true
-	}
-	vendors[9] = false
-	if !reflect.DeepEqual(vendors, c.Vendors) {
-		t.Fail()
-	}
-}
-
-func TestConsentParse_JSSDK(t *testing.T) {
-	var c Consent
-	t2018, err := time.Parse("2006-01-02 15:04:05 MST", "2018-07-15 07:00:00 PDT")
-	noError(t, err)
-	noError(t, c.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA"))
-
-	equal(t, 1, int(c.Version))
-	equal(t, t2018.UTC(), c.Created.UTC())
-	equal(t, t2018.UTC(), c.LastUpdated.UTC())
-
-	equal(t, "EN", c.ConsentLanguage)
-	equal(t, [24]bool{true, true, false, false}, c.PurposesAllowed)
-	equal(t, map[int]bool{1: true, 2: true, 4: true}, c.Vendors)
-}
-
-func TestConsentParse_BackNForth(t *testing.T) {
-	fixtures := map[string]string{
-		// example from official docs
-		"BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA": "BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA", // Official
-
-		// From Java SDK
-		// BitField
-		"BONMj34ONMj34ABACDENALqAAAAAplY": "BONMj34ONMj34ABACDENALqAAAAAplY",
-		// Ranges
-		"BN5lERiOMYEdiAOAWeFRAAYAAaAAptQ":                  "BN5lERiOMYEdiAOAWeFRAAYAAaAAptQ",
-		"BN5lERiOMYEdiAKAWXEND1HoSBE6CAEAApAMgBmgEBxOIE6A": "BN5lERiOMYEdiAKAWXEND1HoSBE6CAEAApAMgBmgEBxOIE6A",
-		"BOOMzbgOOQww_AtABAFRAb-AAAsvOA3gACAAkABgArgBaAF0AMAA1gBuAH8AQQBSgCoAL8AYQBigDIAM0AaABpgDYAOYAdgA8AB6gD4AQoAiABFQCMAI6ASABIgCTAEqAJeATIBQQCiAKSAU4BVQCtAK-AWYBaQC2ALcAXMAvAC-gGAAYcAxQDGAGQAMsAZsA0ADTAGqANcAbMA4ADjAHKAOiAdQB1gDtgHgAeMA9AD2AHzAP4BAACBAEEAIbAREBEgCKQEXARhZeYA": "BOOMzbgOOQww_AtABAFRAb-AAAsvPA2AAKACwAF4ANgAgABTADAAGMAM8AagBrgDoAOoAdwA8gB7gEMAQ4AiQBFgCPAEkAJQASwAmABQwClAKaAVYBWQCwALIAWoAuIBdAF2AL8AYgAx4BkgGUAMyAZwBngDUAGsANiAbQBvgDkgHMAc4A6QB2QDuAO-AeQB5wD3APiAfQB-gEBAIHAQUBDICHAIgAROAioCLQEZsvI",
-		"BONZt-1ONZt-1AHABBENAO-AAAAHCAEAASABmADYAOAAeA": "BONZt-1ONZt-1AHABBENAO-AAAAHCAEAASABmADYAOAAeA",
-
-		// From JS SDK
-		// Ranges
-		"BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA": "BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA",
-	}
-
-	for orig, short := range fixtures {
-		t.Logf(orig)
-		var c Consent
-		err := c.Parse(orig)
-		noError(t, err)
-		equal(t, short, c.String())
-
-		var c2 Consent
-		err = c2.Parse(c.String())
-		noError(t, err)
-		equal(t, c.String(), c2.String())
-	}
+	equal(t, 2, v2.CmpVersion)
 }

--- a/consentv1.go
+++ b/consentv1.go
@@ -1,0 +1,322 @@
+package consent
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"time"
+)
+
+type encodingType byte
+
+const (
+	bitFieldType encodingType = 0
+	rangeType    encodingType = 1
+)
+
+var (
+	// ErrUnexpectedEnd is returned when a consent string is too short
+	ErrUnexpectedEnd = errors.New("consent: unexpected end")
+
+	// ErrUnsupported is returned when a string version is not 1
+	ErrUnsupported = errors.New("consent: version is not supported")
+)
+
+// Consent is a golang representation of an IAB consent string
+//
+// Implementation is done as per IAB Consent String format v1.1:
+// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/68f5e0012a7bdb00867ce9fee57fb67cfe9153e3/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md
+type ConsentV1 struct {
+	Created           time.Time
+	LastUpdated       time.Time
+	CmpID             int
+	CmpVersion        int
+	ConsentScreen     byte
+	ConsentLanguage   string
+	VendorListVersion int
+	PurposesAllowed   [24]bool
+
+	MaxVendorID  int
+	encodingType encodingType
+
+	Vendors map[int]bool
+}
+
+func (c *ConsentV1) Version() byte {
+	return 1
+}
+
+// New creates a new instance of a Consent struct
+func NewConsentV1(cmpID, cmpVersion int, consentScreen byte, lang string, vendorListVerson int, purposesAllowed [24]bool, allowedVendors map[int]bool) ConsentV1 {
+
+	vendors := make(map[int]bool)
+	for k, v := range allowedVendors {
+		vendors[k] = v
+	}
+
+	return ConsentV1{
+		Created:           time.Now(),
+		LastUpdated:       time.Now(),
+		CmpID:             cmpID,
+		CmpVersion:        cmpVersion,
+		ConsentScreen:     consentScreen,
+		ConsentLanguage:   lang,
+		VendorListVersion: vendorListVerson,
+		PurposesAllowed:   purposesAllowed,
+		Vendors:           vendors,
+	}
+}
+
+// Bytes returns raw, i.e. not base64 encoded, consent string bytes
+func (c *ConsentV1) Bytes() []byte {
+	var b bitWriter
+	b.AppendByte(c.Version(), 6)
+	b.AppendInt(c.Created.UnixNano()/int64(time.Second/10), 36)
+	b.AppendInt(c.LastUpdated.UnixNano()/int64(time.Second/10), 36)
+	b.AppendInt(int64(c.CmpID), 12)
+	b.AppendInt(int64(c.CmpVersion), 12)
+	b.AppendByte(c.ConsentScreen, 6)
+	lang := []byte(strings.ToUpper(c.ConsentLanguage))
+	if len(lang) == 2 {
+		b.AppendByte(lang[0]-byte('A'), 6)
+		b.AppendByte(lang[1]-byte('A'), 6)
+	} else {
+		b.AppendByte(byte('X')-byte('A'), 6)
+		b.AppendByte(byte('X')-byte('A'), 6)
+	}
+	b.AppendInt(int64(c.VendorListVersion), 12)
+	b.AppendBools(c.PurposesAllowed[:])
+	b.AppendInt(int64(c.MaxVendorID), 16)
+
+	switch ecType, defConsent, rngCount := c.findSmallest(); ecType {
+	case bitFieldType:
+		b.AppendByte(byte(bitFieldType), 1) // encoding type
+		for i := 1; i <= c.MaxVendorID; i++ {
+			var v byte
+			if c.Vendors[i] {
+				v = 1
+			}
+			b.AppendByte(v, 1)
+		}
+	case rangeType:
+		b.AppendByte(byte(rangeType), 1) // encoding type
+		if defConsent {
+			b.AppendByte(1, 1)
+		} else {
+			b.AppendByte(0, 1)
+		}
+
+		b.AppendInt(rngCount, 12)
+		for i := 1; i <= c.MaxVendorID; i++ {
+			start := i
+			for ; start <= c.MaxVendorID && c.Vendors[start] == defConsent; start++ {
+			}
+			end := start
+			for ; end <= c.MaxVendorID && c.Vendors[end] != defConsent; end++ {
+			}
+
+			if end == start {
+				break
+			} else if end-start == 1 {
+				b.AppendByte(0, 1)
+				b.AppendInt(int64(start), 16)
+			} else {
+				b.AppendByte(1, 1)
+				b.AppendInt(int64(start), 16)
+				b.AppendInt(int64(end-1), 16)
+			}
+			i = end
+		}
+	}
+
+	return b.Bytes()
+}
+
+func (c *ConsentV1) findSmallest() (encodingType, bool, int64) {
+	var bfScore, rtScore, rfScore int
+	// bitfield, range with default consent == true, and range with false
+	var rtRecords, rfRecords int64
+
+	bfScore = c.MaxVendorID
+	rtScore = 1 + 12
+	rfScore = 1 + 12
+
+	for i := 1; i <= c.MaxVendorID; i++ {
+		cur := c.Vendors[i]
+		start := i
+		for ; i <= c.MaxVendorID && c.Vendors[i] == cur; i++ {
+		}
+		end := i
+		i--
+
+		size := 1
+		if end-start == 1 {
+			size += 16
+		} else {
+			size += 16 + 16
+		}
+
+		if cur {
+			rfScore += size
+			rfRecords++
+		} else {
+			rtScore += size
+			rtRecords++
+		}
+	}
+
+	min := bfScore
+	if min > rtScore {
+		min = rtScore
+	}
+	if min > rfScore {
+		min = rfScore
+	}
+
+	if min == rfScore {
+		return rangeType, false, rfRecords
+	} else if min == rtScore {
+		return rangeType, true, rtRecords
+	} else {
+		return bitFieldType, false, 0
+	}
+}
+
+func (c *ConsentV1) outputRange(defConsent bool) (int64, bitWriter) {
+	var b bitWriter
+	var count int64
+	return count, b
+}
+
+// String return a base64-encoded consent string
+func (c *ConsentV1) String() string {
+	return base64.RawURLEncoding.EncodeToString(c.Bytes())
+}
+
+// ParseRaw converts a raw, i.e. non base64-encoded, consent string into the
+// Consent struct
+func (c *ConsentV1) ParseRaw(binary []byte) error {
+	if len(binary) < 21 {
+		return ErrUnexpectedEnd
+	}
+
+	b := newBitReader(binary)
+
+	version, _ := b.ReadByte(6)
+	if version != 1 {
+		return ErrUnsupported
+	}
+
+	dt, _ := b.ReadInt(36)
+	c.Created = time.Unix(dt/10, dt%10*100*1000*1000)
+
+	dt, _ = b.ReadInt(36)
+	c.LastUpdated = time.Unix(dt/10, dt%10*100*1000*1000)
+
+	dt, _ = b.ReadInt(12)
+	c.CmpID = int(dt)
+
+	dt, _ = b.ReadInt(12)
+	c.CmpVersion = int(dt)
+
+	c.ConsentScreen, _ = b.ReadByte(6)
+
+	l1, _ := b.ReadByte(6)
+	l2, _ := b.ReadByte(6)
+	c.ConsentLanguage = string([]byte{l1 + byte('A'), l2 + byte('A')})
+
+	dt, _ = b.ReadInt(12)
+	c.VendorListVersion = int(dt)
+
+	for i := range c.PurposesAllowed {
+		by, _ := b.ReadByte(1)
+		v := false
+		if by == 1 {
+			v = true
+		}
+		c.PurposesAllowed[i] = v
+	}
+
+	dt, _ = b.ReadInt(16)
+	c.MaxVendorID = int(dt)
+
+	by, _ := b.ReadByte(1)
+	c.encodingType = encodingType(by)
+	c.Vendors = make(map[int]bool)
+	switch c.encodingType {
+	case bitFieldType:
+		for i := 1; i <= c.MaxVendorID; i++ {
+			if by, ok := b.ReadByte(1); !ok {
+				return ErrUnexpectedEnd
+			} else if by == 1 {
+				c.Vendors[i] = true
+			}
+		}
+	case rangeType:
+		by, ok := b.ReadByte(1)
+		if !ok {
+			return ErrUnexpectedEnd
+		}
+		defCons := false
+		if by == 1 {
+			defCons = true
+
+			for i := 1; i <= int(c.MaxVendorID); i++ {
+				c.Vendors[i] = true
+			}
+		}
+
+		numEntries, ok := b.ReadInt(12)
+		if !ok {
+			return ErrUnexpectedEnd
+		}
+		for i := 0; i < int(numEntries); i++ {
+			singleOrRange, ok := b.ReadByte(1)
+			if !ok {
+				return ErrUnexpectedEnd
+			}
+			if singleOrRange == 0 { // Single
+				dt, ok = b.ReadInt(16)
+				if !ok {
+					return ErrUnexpectedEnd
+				}
+				c.Vendors[int(dt)] = !defCons
+			} else { // Range
+				start, ok := b.ReadInt(16)
+				if !ok {
+					return ErrUnexpectedEnd
+				}
+				end, ok := b.ReadInt(16)
+				if !ok {
+					return ErrUnexpectedEnd
+				}
+				for j := start; j <= end; j++ {
+					if defCons {
+						delete(c.Vendors, int(j))
+					} else {
+						c.Vendors[int(j)] = true
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Parse parses base64 encoded consent
+func (c *ConsentV1) Parse(data string) error {
+	bytes := []byte(data)
+	bin := make([]byte, base64.RawStdEncoding.DecodedLen(len(bytes)))
+	_, err := base64.RawURLEncoding.Decode(bin, bytes)
+	if err != nil {
+		return err
+	}
+	return c.ParseRaw(bin)
+}
+
+// Parse parses base64 encoded consent
+func ParseV1(data string) (*ConsentV1, error) {
+	c := new(ConsentV1)
+	return c, c.Parse(data)
+}

--- a/consentv1_test.go
+++ b/consentv1_test.go
@@ -1,0 +1,122 @@
+package consent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func noError(t *testing.T, err error) {
+	if err != nil {
+		t.Errorf("Got error: %s", err)
+	}
+}
+
+func equal(t *testing.T, expected, got interface{}) {
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Expected '%s', got '%s'", expected, got)
+	}
+}
+
+func TestConsentString_OfficialDocTest(t *testing.T) {
+	t2017, _ := time.Parse(time.RFC3339Nano, "2017-11-07T19:15:55.4Z")
+	c := ConsentV1{
+		Created:           t2017,
+		LastUpdated:       t2017,
+		CmpID:             7,
+		CmpVersion:        1,
+		ConsentScreen:     3,
+		ConsentLanguage:   "EN",
+		VendorListVersion: 8,
+		PurposesAllowed:   [24]bool{true, true, true, false},
+
+		MaxVendorID:  2011,
+		encodingType: rangeType,
+
+		Vendors: make(map[int]bool),
+	}
+	for i := 0; i < 2012; i++ {
+		c.Vendors[i] = true
+	}
+	delete(c.Vendors, 9)
+
+	equal(t, "BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA", c.String())
+}
+
+func TestConsentParse_OfficialDocTest(t *testing.T) {
+	var c ConsentV1
+	t2017, _ := time.Parse(time.RFC3339Nano, "2017-11-07T19:15:55.4Z")
+	noError(t, c.Parse("BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA"))
+
+	if c.Version() != 1 {
+		t.Fail()
+	}
+	if c.Created.UTC() != t2017 {
+		t.Fail()
+	}
+	if c.LastUpdated.UTC() != t2017 {
+		t.Fail()
+	}
+
+	equal(t, "EN", c.ConsentLanguage)
+	if [24]bool{true, true, true, false} != c.PurposesAllowed {
+		t.Fail()
+	}
+
+	vendors := make(map[int]bool)
+	for i := 1; i < 2012; i++ {
+		vendors[i] = true
+	}
+	vendors[9] = false
+	if !reflect.DeepEqual(vendors, c.Vendors) {
+		t.Fail()
+	}
+}
+
+func TestConsentParse_JSSDK(t *testing.T) {
+	var c ConsentV1
+	t2018, err := time.Parse("2006-01-02 15:04:05 MST", "2018-07-15 07:00:00 PDT")
+	noError(t, err)
+	noError(t, c.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA"))
+
+	equal(t, 1, int(c.Version()))
+	equal(t, t2018.UTC(), c.Created.UTC())
+	equal(t, t2018.UTC(), c.LastUpdated.UTC())
+
+	equal(t, "EN", c.ConsentLanguage)
+	equal(t, [24]bool{true, true, false, false}, c.PurposesAllowed)
+	equal(t, map[int]bool{1: true, 2: true, 4: true}, c.Vendors)
+}
+
+func TestConsentParse_BackNForth(t *testing.T) {
+	fixtures := map[string]string{
+		// example from official docs
+		"BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA": "BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA", // Official
+
+		// From Java SDK
+		// BitField
+		"BONMj34ONMj34ABACDENALqAAAAAplY": "BONMj34ONMj34ABACDENALqAAAAAplY",
+		// Ranges
+		"BN5lERiOMYEdiAOAWeFRAAYAAaAAptQ":                  "BN5lERiOMYEdiAOAWeFRAAYAAaAAptQ",
+		"BN5lERiOMYEdiAKAWXEND1HoSBE6CAEAApAMgBmgEBxOIE6A": "BN5lERiOMYEdiAKAWXEND1HoSBE6CAEAApAMgBmgEBxOIE6A",
+		"BOOMzbgOOQww_AtABAFRAb-AAAsvOA3gACAAkABgArgBaAF0AMAA1gBuAH8AQQBSgCoAL8AYQBigDIAM0AaABpgDYAOYAdgA8AB6gD4AQoAiABFQCMAI6ASABIgCTAEqAJeATIBQQCiAKSAU4BVQCtAK-AWYBaQC2ALcAXMAvAC-gGAAYcAxQDGAGQAMsAZsA0ADTAGqANcAbMA4ADjAHKAOiAdQB1gDtgHgAeMA9AD2AHzAP4BAACBAEEAIbAREBEgCKQEXARhZeYA": "BOOMzbgOOQww_AtABAFRAb-AAAsvPA2AAKACwAF4ANgAgABTADAAGMAM8AagBrgDoAOoAdwA8gB7gEMAQ4AiQBFgCPAEkAJQASwAmABQwClAKaAVYBWQCwALIAWoAuIBdAF2AL8AYgAx4BkgGUAMyAZwBngDUAGsANiAbQBvgDkgHMAc4A6QB2QDuAO-AeQB5wD3APiAfQB-gEBAIHAQUBDICHAIgAROAioCLQEZsvI",
+		"BONZt-1ONZt-1AHABBENAO-AAAAHCAEAASABmADYAOAAeA": "BONZt-1ONZt-1AHABBENAO-AAAAHCAEAASABmADYAOAAeA",
+
+		// From JS SDK
+		// Ranges
+		"BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA": "BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA",
+	}
+
+	for orig, short := range fixtures {
+		t.Logf(orig)
+		var c ConsentV1
+		err := c.Parse(orig)
+		noError(t, err)
+		equal(t, short, c.String())
+
+		var c2 ConsentV1
+		err = c2.Parse(c.String())
+		noError(t, err)
+		equal(t, c.String(), c2.String())
+	}
+}

--- a/consentv2.go
+++ b/consentv2.go
@@ -7,7 +7,6 @@ import (
 	"time"
 )
 
-
 var ErrInvalidPubRestrictionType = errors.New("consent: invalid pub restriction type")
 
 type ConsentV2 struct {
@@ -19,16 +18,16 @@ type ConsentV2 struct {
 	ConsentLanguage   [2]byte
 	VendorListVersion int
 
-	TcfPolicyVersion  byte
-	IsServiceSpecific bool
-	UseNonStandardStacks bool
-	SpecialFeatureOptIns [12]bool
-	PurposesConsent [24]bool // used to be called PurposesAllowed
+	TcfPolicyVersion       byte
+	IsServiceSpecific      bool
+	UseNonStandardStacks   bool
+	SpecialFeatureOptIns   [12]bool
+	PurposesConsent        [24]bool // used to be called PurposesAllowed
 	PurposesLITransparency [24]bool
 
 	// specific jurisdiction disclosures
 	PurposeOneTreatment bool
-	PublisherCC [2]byte // ISO 3166-1 alpha-2 code, encoded with 6 bits per char
+	PublisherCC         [2]byte // ISO 3166-1 alpha-2 code, encoded with 6 bits per char
 
 	// vendor consent section
 	VendorConsent VendorSet
@@ -41,14 +40,14 @@ type ConsentV2 struct {
 
 	// optional:
 	DisclosedVendors VendorSet
-	AllowedVendors VendorSet
-	PublisherTC *PublisherTC
+	AllowedVendors   VendorSet
+	PublisherTC      *PublisherTC
 }
 
 type PubRestriction struct {
-	PurposeID int
+	PurposeID       int
 	RestrictionType byte
-	Vendors VendorSet
+	Vendors         VendorSet
 }
 
 func (c *ConsentV2) Version() byte {
@@ -57,7 +56,7 @@ func (c *ConsentV2) Version() byte {
 
 type VendorSet struct {
 	maxVendorID int
-	Set map[int]bool
+	Set         map[int]bool
 }
 
 func (c *ConsentV2) String() string {
@@ -159,7 +158,7 @@ func (c *ConsentV2) writeCoreString(b *bitWriter) {
 }
 
 func (c *ConsentV2) ParseCore(binary []byte) error {
-	if len(binary) * 8 < 213 {
+	if len(binary)*8 < 213 {
 		return ErrUnexpectedEnd
 	}
 	b := newBitReader(binary)
@@ -192,13 +191,13 @@ func (c *ConsentV2) ParseCore(binary []byte) error {
 	c.TcfPolicyVersion, _ = b.ReadByte(6)
 	c.IsServiceSpecific, _ = b.ReadBit()
 	c.UseNonStandardStacks, _ = b.ReadBit()
-	for i:= 0; i < 12; i++ {
+	for i := 0; i < 12; i++ {
 		c.SpecialFeatureOptIns[i], _ = b.ReadBit()
 	}
-	for i:= 0; i < 24; i++ {
+	for i := 0; i < 24; i++ {
 		c.PurposesConsent[i], _ = b.ReadBit()
 	}
-	for i:= 0; i < 24; i++ {
+	for i := 0; i < 24; i++ {
 		c.PurposesLITransparency[i], _ = b.ReadBit()
 	}
 	c.PurposeOneTreatment, _ = b.ReadBit()
@@ -227,35 +226,35 @@ func (c *ConsentV2) ParseCore(binary []byte) error {
 
 const (
 	disclosedVendorsType byte = 1
-	allowedVendorsType byte = 2
-	publisherTCType byte = 3
+	allowedVendorsType   byte = 2
+	publisherTCType      byte = 3
 )
 
 type PublisherTC struct {
-	PubPurposesConsent [24]bool // true: consent, false: no consent
-	PubPurposesLITransparency [24]bool // true: legitimate interest established
-	CustomPurposesConsent []bool // consent/no consent
-	CustomPurposesLITransparency []bool // legitimate interest established/not established
+	PubPurposesConsent           [24]bool // true: consent, false: no consent
+	PubPurposesLITransparency    [24]bool // true: legitimate interest established
+	CustomPurposesConsent        []bool   // consent/no consent
+	CustomPurposesLITransparency []bool   // legitimate interest established/not established
 }
 
 func (p *PublisherTC) Write(w *bitWriter) {
-	for _, b := range(p.PubPurposesConsent) {
+	for _, b := range p.PubPurposesConsent {
 		w.AppendBit(b)
 	}
-	for _, b := range(p.PubPurposesLITransparency) {
+	for _, b := range p.PubPurposesLITransparency {
 		w.AppendBit(b)
 	}
 	w.AppendInt(int64(len(p.CustomPurposesConsent)), 6)
-	for _, b := range(p.CustomPurposesConsent) {
+	for _, b := range p.CustomPurposesConsent {
 		w.AppendBit(b)
 	}
 
-	for _, b := range(p.CustomPurposesLITransparency) {
+	for _, b := range p.CustomPurposesLITransparency {
 		w.AppendBit(b)
 	}
 }
 
-func(c *ConsentV2) ParseNonCoreSegment(binary []byte) error {
+func (c *ConsentV2) ParseNonCoreSegment(binary []byte) error {
 	b := newBitReader(binary)
 	segmentType, ok := b.ReadByte(3)
 	if !ok {
@@ -377,11 +376,10 @@ func (c *ConsentV2) Parse(data string) error {
 }
 
 const (
-	RestrictionTypeNotAllowed byte = 0
-	RestrictionTypeRequireConsent byte = 1
+	RestrictionTypeNotAllowed                byte = 0
+	RestrictionTypeRequireConsent            byte = 1
 	RestrictionTypeRequireLegitimateInterest byte = 2
 )
-
 
 func parsePubRestrictions(b *bitReader) ([]PubRestriction, error) {
 	numPubRestrictions, ok := b.ReadInt(12)
@@ -539,12 +537,12 @@ func AppendRange(b *bitWriter, vendorSet map[int]bool, maxVendorID int, numEntri
 				rangeEnd = i
 			}
 			if rangeStart == rangeEnd { // single entry
-				b.AppendByte(0, 1)// isARange
+				b.AppendByte(0, 1)                 // isARange
 				b.AppendInt(int64(rangeStart), 16) // only vendor id
 			} else { // range
-				b.AppendByte(1, 1)// isARange
+				b.AppendByte(1, 1)                 // isARange
 				b.AppendInt(int64(rangeStart), 16) // first vendor id
-				b.AppendInt(int64(rangeEnd), 16) // last vendor id
+				b.AppendInt(int64(rangeEnd), 16)   // last vendor id
 			}
 
 			vendorID = rangeEnd + 1

--- a/consentv2.go
+++ b/consentv2.go
@@ -1,0 +1,553 @@
+package consent
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"time"
+)
+
+
+var ErrInvalidPubRestrictionType = errors.New("consent: invalid pub restriction type")
+
+type ConsentV2 struct {
+	Created           time.Time
+	LastUpdated       time.Time
+	CmpID             int
+	CmpVersion        int
+	ConsentScreen     byte
+	ConsentLanguage   [2]byte
+	VendorListVersion int
+
+	TcfPolicyVersion  byte
+	IsServiceSpecific bool
+	UseNonStandardStacks bool
+	SpecialFeatureOptIns [12]bool
+	PurposesConsent [24]bool // used to be called PurposesAllowed
+	PurposesLITransparency [24]bool
+
+	// specific jurisdiction disclosures
+	PurposeOneTreatment bool
+	PublisherCC [2]byte // ISO 3166-1 alpha-2 code, encoded with 6 bits per char
+
+	// vendor consent section
+	VendorConsent VendorSet
+
+	// Vendor legitimate interest section
+	VendorLegitimateInterest VendorSet
+
+	// publisher restrictions section
+	PubRestrictions []PubRestriction
+
+	// optional:
+	DisclosedVendors VendorSet
+	AllowedVendors VendorSet
+	PublisherTC *PublisherTC
+}
+
+type PubRestriction struct {
+	PurposeID int
+	RestrictionType byte
+	Vendors VendorSet
+}
+
+func (c *ConsentV2) Version() byte {
+	return 2
+}
+
+type VendorSet struct {
+	maxVendorID int
+	Set map[int]bool
+}
+
+func (c *ConsentV2) String() string {
+	var b bitWriter
+	c.writeCoreString(&b)
+	coreBytes := b.Bytes()
+	totalEncodedByteLen := base64.RawURLEncoding.EncodedLen(len(coreBytes))
+
+	var disclosedVendorBytes, allowedVendorBytes, publisherTCBytes []byte
+	if len(c.DisclosedVendors.Set) != 0 {
+		var b bitWriter
+		b.AppendByte(disclosedVendorsType, 3)
+		c.DisclosedVendors.AppendRangeOrBitField(&b)
+		disclosedVendorBytes = b.Bytes()
+		totalEncodedByteLen += base64.RawURLEncoding.EncodedLen(len(disclosedVendorBytes)) + 1
+	}
+	if len(c.AllowedVendors.Set) != 0 {
+		var b bitWriter
+		b.AppendByte(allowedVendorsType, 3)
+		c.AllowedVendors.AppendRangeOrBitField(&b)
+		allowedVendorBytes = b.Bytes()
+		totalEncodedByteLen += base64.RawURLEncoding.EncodedLen(len(allowedVendorBytes)) + 1
+	}
+
+	if c.PublisherTC != nil {
+		var b bitWriter
+		b.AppendByte(publisherTCType, 3)
+		c.PublisherTC.Write(&b)
+		publisherTCBytes = b.Bytes()
+		totalEncodedByteLen += base64.RawURLEncoding.EncodedLen(len(publisherTCBytes)) + 1
+	}
+
+	dst := make([]byte, totalEncodedByteLen)
+	base64.RawURLEncoding.Encode(dst, coreBytes)
+	offset := base64.RawURLEncoding.EncodedLen((len(coreBytes)))
+	if len(disclosedVendorBytes) > 0 {
+		dst[offset] = '.'
+		offset++
+		base64.RawURLEncoding.Encode(dst[offset:], disclosedVendorBytes)
+		offset += base64.RawURLEncoding.EncodedLen(len(disclosedVendorBytes))
+	}
+	if len(allowedVendorBytes) > 0 {
+		dst[offset] = '.'
+		offset += 1
+		base64.RawURLEncoding.Encode(dst[offset:], allowedVendorBytes)
+		offset += base64.RawURLEncoding.EncodedLen(len(allowedVendorBytes))
+	}
+	if len(publisherTCBytes) > 0 {
+		dst[offset] = '.'
+		offset += 1
+		base64.RawURLEncoding.Encode(dst[offset:], publisherTCBytes)
+		offset += base64.RawURLEncoding.EncodedLen(len(publisherTCBytes))
+	}
+
+	return string(dst)
+}
+
+func (c *ConsentV2) writeCoreString(b *bitWriter) {
+	b.AppendByte(c.Version(), 6)
+	b.AppendInt(c.Created.UnixNano()/int64(time.Second/10), 36)
+	b.AppendInt(c.LastUpdated.UnixNano()/int64(time.Second/10), 36)
+	b.AppendInt(int64(c.CmpID), 12)
+	b.AppendInt(int64(c.CmpVersion), 12)
+	b.AppendByte(c.ConsentScreen, 6)
+	b.AppendByte(c.ConsentLanguage[0]-byte('A'), 6)
+	b.AppendByte(c.ConsentLanguage[1]-byte('A'), 6)
+	b.AppendInt(int64(c.VendorListVersion), 12)
+	b.AppendByte(c.TcfPolicyVersion, 6)
+	b.AppendBit(c.IsServiceSpecific)
+	b.AppendBit(c.UseNonStandardStacks)
+
+	for _, optIn := range c.SpecialFeatureOptIns {
+		b.AppendBit(optIn)
+	}
+
+	for _, consent := range c.PurposesConsent {
+		b.AppendBit(consent)
+	}
+
+	for _, tr := range c.PurposesLITransparency {
+		b.AppendBit(tr)
+	}
+
+	b.AppendBit(c.PurposeOneTreatment)
+
+	b.AppendByte(c.PublisherCC[0]-byte('A'), 6)
+	b.AppendByte(c.PublisherCC[1]-byte('A'), 6)
+
+	c.VendorConsent.AppendRangeOrBitField(b)
+	c.VendorLegitimateInterest.AppendRangeOrBitField(b)
+
+	b.AppendInt(int64(len(c.PubRestrictions)), 12)
+	for _, pubRestriction := range c.PubRestrictions {
+		b.AppendInt(int64(pubRestriction.PurposeID), 6)
+		b.AppendByte(pubRestriction.RestrictionType, 2)
+		numEntries, _ := pubRestriction.Vendors.getRangeSizes()
+		AppendRange(b, pubRestriction.Vendors.Set, pubRestriction.Vendors.maxVendorID, numEntries)
+	}
+}
+
+func (c *ConsentV2) ParseCore(binary []byte) error {
+	if len(binary) * 8 < 213 {
+		return ErrUnexpectedEnd
+	}
+	b := newBitReader(binary)
+	version, _ := b.ReadByte(6)
+	if version != 2 {
+		return ErrUnsupported
+	}
+
+	dt, _ := b.ReadInt(36)
+	c.Created = time.Unix(dt/10, dt%10*100*1000*1000)
+
+	dt, _ = b.ReadInt(36)
+	c.LastUpdated = time.Unix(dt/10, dt%10*100*1000*1000)
+
+	dt, _ = b.ReadInt(12)
+	c.CmpID = int(dt)
+
+	dt, _ = b.ReadInt(12)
+	c.CmpVersion = int(dt)
+
+	c.ConsentScreen, _ = b.ReadByte(6)
+
+	l1, _ := b.ReadByte(6)
+	l2, _ := b.ReadByte(6)
+	c.ConsentLanguage = [2]byte{l1 + byte('A'), l2 + byte('A')}
+
+	dt, _ = b.ReadInt(12)
+	c.VendorListVersion = int(dt)
+
+	c.TcfPolicyVersion, _ = b.ReadByte(6)
+	c.IsServiceSpecific, _ = b.ReadBit()
+	c.UseNonStandardStacks, _ = b.ReadBit()
+	for i:= 0; i < 12; i++ {
+		c.SpecialFeatureOptIns[i], _ = b.ReadBit()
+	}
+	for i:= 0; i < 24; i++ {
+		c.PurposesConsent[i], _ = b.ReadBit()
+	}
+	for i:= 0; i < 24; i++ {
+		c.PurposesLITransparency[i], _ = b.ReadBit()
+	}
+	c.PurposeOneTreatment, _ = b.ReadBit()
+	l1, _ = b.ReadByte(6)
+	l2, _ = b.ReadByte(6)
+	c.PublisherCC = [2]byte{l1 + byte('A'), l2 + byte('A')}
+
+	var err error
+	c.VendorConsent, err = parseVendorSet(&b)
+	if err != nil {
+		return err
+	}
+
+	c.VendorLegitimateInterest, err = parseVendorSet(&b)
+	if err != nil {
+		return err
+	}
+
+	c.PubRestrictions, err = parsePubRestrictions(&b)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const (
+	disclosedVendorsType byte = 1
+	allowedVendorsType byte = 2
+	publisherTCType byte = 3
+)
+
+type PublisherTC struct {
+	PubPurposesConsent [24]bool // true: consent, false: no consent
+	PubPurposesLITransparency [24]bool // true: legitimate interest established
+	CustomPurposesConsent []bool // consent/no consent
+	CustomPurposesLITransparency []bool // legitimate interest established/not established
+}
+
+func (p *PublisherTC) Write(w *bitWriter) {
+	for _, b := range(p.PubPurposesConsent) {
+		w.AppendBit(b)
+	}
+	for _, b := range(p.PubPurposesLITransparency) {
+		w.AppendBit(b)
+	}
+	w.AppendInt(int64(len(p.CustomPurposesConsent)), 6)
+	for _, b := range(p.CustomPurposesConsent) {
+		w.AppendBit(b)
+	}
+
+	for _, b := range(p.CustomPurposesLITransparency) {
+		w.AppendBit(b)
+	}
+}
+
+func(c *ConsentV2) ParseNonCoreSegment(binary []byte) error {
+	b := newBitReader(binary)
+	segmentType, ok := b.ReadByte(3)
+	if !ok {
+		return ErrUnexpectedEnd
+	}
+	switch segmentType {
+	case disclosedVendorsType:
+		return c.parseDisclosedVendors(&b)
+	case allowedVendorsType:
+		return c.parseAllowedVendors(&b)
+	case publisherTCType:
+		return c.parsePublisherTC(&b)
+	default:
+		return nil
+	}
+}
+
+// assumes segment type bits have already been consumed
+func (c *ConsentV2) parseDisclosedVendors(b *bitReader) error {
+	m, err := parseVendorSet(b)
+	if err != nil {
+		return err
+	}
+	c.DisclosedVendors = m
+	return nil
+}
+
+// assumes segment type bits have already been consumed
+func (c *ConsentV2) parseAllowedVendors(b *bitReader) error {
+	m, err := parseVendorSet(b)
+	if err != nil {
+		return err
+	}
+	c.AllowedVendors = m
+	return nil
+}
+
+// assumes segment type bits have already been consumed
+func (c *ConsentV2) parsePublisherTC(b *bitReader) error {
+	publisherTC := &PublisherTC{}
+	var ok bool
+	for i := range publisherTC.PubPurposesConsent {
+		publisherTC.PubPurposesConsent[i], ok = b.ReadBit()
+		if !ok {
+			return ErrUnexpectedEnd
+		}
+	}
+
+	for i := range publisherTC.PubPurposesLITransparency {
+		publisherTC.PubPurposesLITransparency[i], ok = b.ReadBit()
+		if !ok {
+			return ErrUnexpectedEnd
+		}
+	}
+
+	numCustomPurposes, ok := b.ReadInt(6)
+	if !ok {
+		return ErrUnexpectedEnd
+	}
+
+	customPurposesConsent := make([]bool, numCustomPurposes)
+	for i := 0; i < int(numCustomPurposes); i++ {
+		customPurposesConsent[i], ok = b.ReadBit()
+		if !ok {
+			return ErrUnexpectedEnd
+		}
+	}
+
+	customPurposesLITransparency := make([]bool, numCustomPurposes)
+	for i := 0; i < int(numCustomPurposes); i++ {
+		customPurposesLITransparency[i], ok = b.ReadBit()
+		if !ok {
+			return ErrUnexpectedEnd
+		}
+	}
+	publisherTC.CustomPurposesConsent = customPurposesConsent
+	publisherTC.CustomPurposesLITransparency = customPurposesLITransparency
+	c.PublisherTC = publisherTC
+	return nil
+}
+
+func ParseV2(s string) (*ConsentV2, error) {
+	c := new(ConsentV2)
+	return c, c.Parse(s)
+}
+
+func (c *ConsentV2) Parse(data string) error {
+	segments := strings.Split(data, ".")
+	if len(segments) == 0 {
+		return ErrUnexpectedEnd
+	}
+	coreSegment := segments[0]
+	bytes := []byte(coreSegment)
+	bin := make([]byte, base64.RawStdEncoding.DecodedLen(len(bytes)))
+	_, err := base64.RawURLEncoding.Decode(bin, bytes)
+	if err != nil {
+		return err
+	}
+
+	err = c.ParseCore(bin)
+	if err != nil {
+		return err
+	}
+
+	for i := 1; i < len(segments); i++ {
+		segment := segments[i]
+		bytes := []byte(segment)
+		bin := make([]byte, base64.RawStdEncoding.DecodedLen(len(bytes)))
+		_, err := base64.RawURLEncoding.Decode(bin, bytes)
+		if err != nil {
+			return nil
+		}
+		err = c.ParseNonCoreSegment(bin)
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+const (
+	RestrictionTypeNotAllowed byte = 0
+	RestrictionTypeRequireConsent byte = 1
+	RestrictionTypeRequireLegitimateInterest byte = 2
+)
+
+
+func parsePubRestrictions(b *bitReader) ([]PubRestriction, error) {
+	numPubRestrictions, ok := b.ReadInt(12)
+	if !ok {
+		return nil, ErrUnexpectedEnd
+	}
+	restrictions := make([]PubRestriction, 0, int(numPubRestrictions))
+	for i := 0; i < int(numPubRestrictions); i++ {
+		pr := PubRestriction{}
+		purposeID, ok := b.ReadInt(6)
+		if !ok {
+			return nil, ErrUnexpectedEnd
+		}
+		pr.PurposeID = int(purposeID)
+		pr.RestrictionType, ok = b.ReadByte(2)
+		if !ok {
+			return nil, ErrUnexpectedEnd
+		}
+		if pr.RestrictionType > 2 {
+			return []PubRestriction{}, ErrInvalidPubRestrictionType
+		}
+		vendors, maxVendorID, err := parseRange(b) // NOTE: this one can't be a bit field for some reason
+		if err != nil {
+			return nil, err
+		}
+		pr.Vendors = VendorSet{Set: vendors, maxVendorID: maxVendorID}
+		restrictions = append(restrictions, pr)
+	}
+	return restrictions, nil
+}
+
+func parseVendorSet(b *bitReader) (VendorSet, error) {
+	maxVendorID, ok := b.ReadInt(16)
+	if !ok {
+		return VendorSet{}, ErrUnexpectedEnd
+	}
+	isRangeEncoding, ok := b.ReadBit()
+	if !ok {
+		return VendorSet{}, ErrUnexpectedEnd
+	}
+	var err error
+	var set map[int]bool
+	if isRangeEncoding {
+		set, _, err = parseRange(b)
+	} else {
+		set, err = parseBitField(b, int(maxVendorID))
+	}
+
+	if err != nil {
+		return VendorSet{}, err
+	}
+
+	return VendorSet{Set: set, maxVendorID: int(maxVendorID)}, nil
+}
+
+func parseRange(b *bitReader) (map[int]bool, int, error) { // second return value is max vendor id in the set
+	numEntries, ok := b.ReadInt(12)
+	var maxVendorID int
+	if !ok {
+		return nil, 0, ErrUnexpectedEnd
+	}
+	vendors := make(map[int]bool)
+	for i := 0; i < int(numEntries); i++ {
+		isARange, _ := b.ReadBit()
+		startOrOnlyVendorID, ok := b.ReadInt(16)
+		if !ok {
+			return nil, 0, ErrUnexpectedEnd
+		}
+		endVendorID := startOrOnlyVendorID
+		if isARange {
+			endVendorID, ok = b.ReadInt(16)
+			if !ok {
+				return nil, 0, ErrUnexpectedEnd
+			}
+		}
+		for id := startOrOnlyVendorID; id <= endVendorID; id++ {
+			vendors[int(id)] = true
+			maxVendorID = int(id)
+		}
+	}
+
+	return vendors, maxVendorID, nil
+}
+
+func parseBitField(b *bitReader, maxVendorID int) (map[int]bool, error) {
+	vendors := map[int]bool{}
+	for vendorID := 1; vendorID <= maxVendorID; vendorID++ {
+		vendorBit, ok := b.ReadBit()
+		if !ok {
+			return nil, ErrUnexpectedEnd
+		}
+		if vendorBit {
+			vendors[vendorID] = true
+		}
+	}
+	return vendors, nil
+}
+
+func (s *VendorSet) AppendRangeOrBitField(b *bitWriter) {
+	numRangeEntries, rangeSizeInBits := s.getRangeSizes()
+	isRange := false
+	if rangeSizeInBits < s.maxVendorID {
+		isRange = true
+	}
+
+	b.AppendInt(int64(s.maxVendorID), 16)
+	if isRange {
+		b.AppendByte(1, 1) // encoding type
+		AppendRange(b, s.Set, s.maxVendorID, numRangeEntries)
+	} else {
+		b.AppendByte(0, 1) // encoding type
+		AppendBitField(b, s.Set, s.maxVendorID)
+	}
+}
+
+func AppendBitField(b *bitWriter, vendorSet map[int]bool, maxVendorID int) {
+	for vendorID := 1; vendorID <= maxVendorID; vendorID++ {
+		var bit byte = 0
+		if vendorSet[vendorID] {
+			bit = 1
+		}
+		b.AppendByte(bit, 1)
+	}
+}
+
+func (v *VendorSet) getRangeSizes() (int, int) { // numEntries, number of bits
+	var numEntries, bitCount int
+	for vendorID := 1; vendorID <= v.maxVendorID; vendorID++ {
+		if v.Set[vendorID] {
+			rangeStart := vendorID
+			rangeEnd := vendorID
+			for i := rangeStart + 1; i <= v.maxVendorID && v.Set[i]; i++ {
+				rangeEnd = i
+			}
+			if rangeStart == rangeEnd { // single entry
+				bitCount += 17
+			} else { // range
+				bitCount += 33
+			}
+
+			numEntries += 1
+			vendorID = rangeEnd + 1
+		}
+	}
+	return numEntries, bitCount + 12
+}
+
+func AppendRange(b *bitWriter, vendorSet map[int]bool, maxVendorID int, numEntries int) {
+	b.AppendInt(int64(numEntries), 12)
+	for vendorID := 1; vendorID <= maxVendorID; vendorID++ {
+		if vendorSet[vendorID] {
+			rangeStart := vendorID
+			rangeEnd := vendorID
+			for i := rangeStart + 1; i <= maxVendorID && vendorSet[i]; i++ {
+				rangeEnd = i
+			}
+			if rangeStart == rangeEnd { // single entry
+				b.AppendByte(0, 1)// isARange
+				b.AppendInt(int64(rangeStart), 16) // only vendor id
+			} else { // range
+				b.AppendByte(1, 1)// isARange
+				b.AppendInt(int64(rangeStart), 16) // first vendor id
+				b.AppendInt(int64(rangeEnd), 16) // last vendor id
+			}
+
+			vendorID = rangeEnd + 1
+		}
+	}
+}

--- a/consentv2_test.go
+++ b/consentv2_test.go
@@ -1,0 +1,127 @@
+package consent
+
+import (
+	"testing"
+)
+
+func TestConsentV2Parse(t *testing.T) {
+	s := "COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA"
+	c := ConsentV2{}
+
+	err := c.Parse(s)
+	equal(t, err, nil)
+	equal(t, int(c.Version()), 2)
+	equal(t, c.Created.String(), "2020-01-26 18:01:00 +0100 CET")
+	equal(t, c.LastUpdated.String(), "2021-02-02 18:01:00 +0100 CET")
+	equal(t, c.CmpID, 675)
+	equal(t, c.CmpVersion, 2)
+	equal(t, int(c.ConsentScreen), 1)
+	equal(t, string(c.ConsentLanguage[:]), "EN")
+	equal(t, c.VendorListVersion, 15)
+	equal(t, int(c.TcfPolicyVersion), 2)
+	equal(t, c.IsServiceSpecific, false)
+	equal(t, c.UseNonStandardStacks, false)
+	equal(t, string(c.PublisherCC[:]), "AA")
+	equal(t, c.PurposeOneTreatment, true)
+	equal(t, c.SpecialFeatureOptIns, [12]bool{true, false})
+	equal(t, c.PurposesConsent, [24]bool{false, true, false, false, false, false, false, false, false, true})
+	equal(t, c.PurposesLITransparency, [24]bool{false, true, false, false, false, false, false, false, true})
+
+	equal(t, c.String(), s)
+}
+
+
+func TestConsentV2ParseVendorLegitimateInterest(t *testing.T) {
+	s := "COrEAV4OrXx94ACABBENAHCIAD-AAAAAAACAAxAAAAgAIAwgAgAAAAEAgQAAAAAEAYQAQAAAACAAAABAAA"
+	c := ConsentV2{}
+
+	err := c.Parse(s)
+	equal(t, err, nil)
+	equal(t, c.VendorLegitimateInterest.Set, map[int]bool{
+		37: true,
+		47: true,
+		48: true,
+		53: true,
+		65: true,
+		98: true,
+		129: true,
+	})
+
+	equal(t, c.String(), s)
+}
+
+func TestConsentV2ParseDisclosedAndAllowedVendors(t *testing.T) {
+	s := "COrEAV4OrXx94ACABBENAHCIAD-AAAAAAACAAxAAAAgAIAwgAgAAAAEAgQAAAAAEAYQAQAAAACAAAABAAA.IBAgAAAgAIAwgAgAAAAEAAAACA.QAagAQAgAIAwgA"
+	c := ConsentV2{}
+	err := c.Parse(s)
+	equal(t, err, nil)
+	equal(t, c.AllowedVendors.Set, map[int]bool{
+		12: true,
+		23: true,
+		37: true,
+		47: true,
+		48: true,
+		53: true,
+	})
+
+	equal(t, c.DisclosedVendors.Set, map[int]bool{
+		23: true,
+		37: true,
+		47: true,
+		48: true,
+		53: true,
+		65: true,
+		98: true,
+		129: true,
+	})
+
+	equal(t, c.String(), s)
+}
+
+func TestConsentV2ParsePubRestrictions(t *testing.T) {
+	s :=  "COuQACgOuQACgM-AAAENAPCAAAAAAAAAAAAAAAAAAABgoAAQAAHAAA"
+	c := ConsentV2{}
+	err := c.Parse(s)
+	equal(t, err, nil)
+	expectedRestrictions := []PubRestriction{
+		{PurposeID: 1, RestrictionType: RestrictionTypeRequireConsent, Vendors: VendorSet{}},
+		{PurposeID: 2, RestrictionType: RestrictionTypeNotAllowed, Vendors: VendorSet{}},
+		{PurposeID: 3, RestrictionType: RestrictionTypeRequireLegitimateInterest, Vendors: VendorSet{}},
+	}
+
+	for i := range expectedRestrictions {
+		equal(t, c.PubRestrictions[i].PurposeID, expectedRestrictions[i].PurposeID)
+		equal(t, c.PubRestrictions[i].RestrictionType, expectedRestrictions[i].RestrictionType)
+	}
+	equal(t, c.String(), s)
+
+	vs := VendorSet{Set: map[int]bool{1: true, 3: true, 4: true}, maxVendorID: 4}
+	c.PubRestrictions[0].Vendors = vs
+	s2 := c.String()
+	c2 := ConsentV2{}
+	err = c2.Parse(s2)
+	equal(t, err, nil)
+	expectedRestrictions[0].Vendors = vs
+	for i := range expectedRestrictions {
+		equal(t, c2.PubRestrictions[i].PurposeID, expectedRestrictions[i].PurposeID)
+		equal(t, c2.PubRestrictions[i].RestrictionType, expectedRestrictions[i].RestrictionType)
+	}
+	equal(t, c2.String(), s2)
+}
+
+
+func TestConsentV2ParsePublisherTC(t *testing.T) {
+	s := "COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA.cAAAAAAAITg"
+	c := ConsentV2{}
+	err := c.Parse(s)
+	equal(t, err, nil)
+
+	equal(t, c.PublisherTC.PubPurposesConsent, [24]bool{true})
+	expectedPPLIT := [24]bool{}
+	expectedPPLIT[23] = true
+	equal(t, c.PublisherTC.PubPurposesLITransparency, expectedPPLIT)
+	equal(t, c.PublisherTC.CustomPurposesConsent, []bool{false, true})
+	equal(t, c.PublisherTC.CustomPurposesLITransparency, []bool{true, true})
+
+	equal(t, c.String(), s)
+}

--- a/consentv2_test.go
+++ b/consentv2_test.go
@@ -30,7 +30,6 @@ func TestConsentV2Parse(t *testing.T) {
 	equal(t, c.String(), s)
 }
 
-
 func TestConsentV2ParseVendorLegitimateInterest(t *testing.T) {
 	s := "COrEAV4OrXx94ACABBENAHCIAD-AAAAAAACAAxAAAAgAIAwgAgAAAAEAgQAAAAAEAYQAQAAAACAAAABAAA"
 	c := ConsentV2{}
@@ -38,12 +37,12 @@ func TestConsentV2ParseVendorLegitimateInterest(t *testing.T) {
 	err := c.Parse(s)
 	equal(t, err, nil)
 	equal(t, c.VendorLegitimateInterest.Set, map[int]bool{
-		37: true,
-		47: true,
-		48: true,
-		53: true,
-		65: true,
-		98: true,
+		37:  true,
+		47:  true,
+		48:  true,
+		53:  true,
+		65:  true,
+		98:  true,
 		129: true,
 	})
 
@@ -65,13 +64,13 @@ func TestConsentV2ParseDisclosedAndAllowedVendors(t *testing.T) {
 	})
 
 	equal(t, c.DisclosedVendors.Set, map[int]bool{
-		23: true,
-		37: true,
-		47: true,
-		48: true,
-		53: true,
-		65: true,
-		98: true,
+		23:  true,
+		37:  true,
+		47:  true,
+		48:  true,
+		53:  true,
+		65:  true,
+		98:  true,
 		129: true,
 	})
 
@@ -79,7 +78,7 @@ func TestConsentV2ParseDisclosedAndAllowedVendors(t *testing.T) {
 }
 
 func TestConsentV2ParsePubRestrictions(t *testing.T) {
-	s :=  "COuQACgOuQACgM-AAAENAPCAAAAAAAAAAAAAAAAAAABgoAAQAAHAAA"
+	s := "COuQACgOuQACgM-AAAENAPCAAAAAAAAAAAAAAAAAAABgoAAQAAHAAA"
 	c := ConsentV2{}
 	err := c.Parse(s)
 	equal(t, err, nil)
@@ -108,7 +107,6 @@ func TestConsentV2ParsePubRestrictions(t *testing.T) {
 	}
 	equal(t, c2.String(), s2)
 }
-
 
 func TestConsentV2ParsePublisherTC(t *testing.T) {
 	s := "COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA.cAAAAAAAITg"

--- a/consentv2_test.go
+++ b/consentv2_test.go
@@ -9,7 +9,7 @@ func TestConsentV2Parse(t *testing.T) {
 	c := ConsentV2{}
 
 	err := c.Parse(s)
-	equal(t, err, nil)
+	noError(t, err)
 	equal(t, int(c.Version()), 2)
 	equal(t, c.Created.String(), "2020-01-26 18:01:00 +0100 CET")
 	equal(t, c.LastUpdated.String(), "2021-02-02 18:01:00 +0100 CET")
@@ -53,7 +53,7 @@ func TestConsentV2ParseDisclosedAndAllowedVendors(t *testing.T) {
 	s := "COrEAV4OrXx94ACABBENAHCIAD-AAAAAAACAAxAAAAgAIAwgAgAAAAEAgQAAAAAEAYQAQAAAACAAAABAAA.IBAgAAAgAIAwgAgAAAAEAAAACA.QAagAQAgAIAwgA"
 	c := ConsentV2{}
 	err := c.Parse(s)
-	equal(t, err, nil)
+	noError(t, err)
 	equal(t, c.AllowedVendors.Set, map[int]bool{
 		12: true,
 		23: true,
@@ -81,7 +81,7 @@ func TestConsentV2ParsePubRestrictions(t *testing.T) {
 	s := "COuQACgOuQACgM-AAAENAPCAAAAAAAAAAAAAAAAAAABgoAAQAAHAAA"
 	c := ConsentV2{}
 	err := c.Parse(s)
-	equal(t, err, nil)
+	noError(t, err)
 	expectedRestrictions := []PubRestriction{
 		{PurposeID: 1, RestrictionType: RestrictionTypeRequireConsent, Vendors: VendorSet{}},
 		{PurposeID: 2, RestrictionType: RestrictionTypeNotAllowed, Vendors: VendorSet{}},
@@ -99,7 +99,7 @@ func TestConsentV2ParsePubRestrictions(t *testing.T) {
 	s2 := c.String()
 	c2 := ConsentV2{}
 	err = c2.Parse(s2)
-	equal(t, err, nil)
+	noError(t, err)
 	expectedRestrictions[0].Vendors = vs
 	for i := range expectedRestrictions {
 		equal(t, c2.PubRestrictions[i].PurposeID, expectedRestrictions[i].PurposeID)

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,9 @@
 /*
 Package consent contains IAB consent string encode and decode implementations.
 
-Create a new consent with the consent.New function:
+Version 1
+
+Create a new consent (v1) with the consent.NewConsentV1 function:
 
  cmpID := 1
  cmpVersion := 1
@@ -11,12 +13,12 @@ Create a new consent with the consent.New function:
  purposesAllowed := [24]bool{true, true, true, true}
  allowedVendors := map[int]bool{10: true, 64: true}
 
- c1 := consent.New(cmpID, cmpVersion, consentScreen, lang,
+ c1 := consent.NewConsentV1(cmpID, cmpVersion, consentScreen, lang,
  	vendorListVersion, purposesAllowed, allowedVendors)
 
-Decode an existing string with consent.Parse:
+Decode an existing string with consent.ParseV1:
 
- c2, err := consent.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
+ c2, err := consent.ParseV1("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
 
 In both cases you can read and modify a struct as you want:
 
@@ -29,6 +31,19 @@ In both cases you can read and modify a struct as you want:
 At anytime export it as an IAB base64-encoded consent string:
 
  c2.String()
+
+Parsing a consent string if you don't know its version
+
+ c, err = consent.Parse("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA")
+ println(c.Version()) // prints 2
+ // you can cast the parsed value to the matching Consent struct:
+ cv2, ok := v.(*ConsentV2) 
+
+You can also only parse the version information from a consent string
+without parsing the whole string:
+
+ version, err = ParseConsentVersion("BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA")
+ println(version) // prints 1
 
 */
 package consent

--- a/example/decode/decode.go
+++ b/example/decode/decode.go
@@ -14,7 +14,7 @@ func main() {
 		str = os.Args[1]
 	}
 
-	c, err := consent.Parse(str)
+	c, err := consent.ParseV1(str)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/example/readme/readme.go
+++ b/example/readme/readme.go
@@ -17,13 +17,13 @@ func main() {
 	purposesAllowed := [24]bool{true, true, true, true}
 	allowedVendors := map[int]bool{10: true, 64: true}
 
-	c1 := consent.New(cmpID, cmpVersion, consentScreen, lang,
+	c1 := consent.NewConsentV1(cmpID, cmpVersion, consentScreen, lang,
 		vendorListVersion, purposesAllowed, allowedVendors)
 
 	fmt.Println(c1.String())
 
 	// Decode an existing consent
-	c2, err := consent.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
+	c2, err := consent.ParseV1("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -35,4 +35,27 @@ func main() {
 	// Patch an existing consent
 	c2.Vendors[999] = true
 	fmt.Println(c2.String())
+
+	// Decode a consent v2 string
+	cv2, err := consent.ParseV2("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA")
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Last modified: %s, vendors allowed: %v\n",
+		cv2.LastUpdated, cv2.VendorConsent)
+
+	// decode a consent string without knowing the version beforehand
+	cvx, err := consent.Parse("BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA")
+	if err != nil {
+	fmt.Println(err)
+		os.Exit(1)
+	}
+	switch c3 := cvx.(type) {
+	case *consent.ConsentV1:
+		fmt.Printf("V1. PurposesAllowed: %v\n", c3.PurposesAllowed)
+	case *consent.ConsentV2:
+		fmt.Printf("V2. PurposesConsent: %v\n", c3.PurposesConsent)
+	}
 }


### PR DESCRIPTION
It's not obvious from the diff, but I `git mv`ed `consent.go` to `consentv1.go`, so almost everything in that file is the same as before, except for renaming the `Consent` type to `ConsentV1` and `Parse` to `ParseV1` and I removed the `Version` from the struct because it's always 1.