### PR TITLE
Add validation-only parsing mode that doesn't build consent data structure

### DIFF
--- a/consent.go
+++ b/consent.go
@@ -32,3 +32,17 @@ func Parse(s string) (Consent, error) {
 	}
 	return nil, nil // unreachable
 }
+
+func Validate(s string) error {
+	v, err := ParseConsentVersion(s)
+	if err != nil {
+		return err
+	}
+	switch v {
+	case 1:
+		return ValidateV1(s)
+	case 2:
+		return ValidateV2(s)
+	}
+	return nil // unreachable
+}

--- a/consent_test.go
+++ b/consent_test.go
@@ -1,12 +1,16 @@
 package consent
 
 import (
+	"encoding/base64"
 	"testing"
 )
 
 const (
 	csv1 = "BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA"
 	csv2 = "COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA"
+	invalidVersionCS = "DOtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA"
+	truncatedCS = "COtybn4PAA"
+	nonB64CS = "COtybn4PA*zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA"
 )
 
 func TestParseVersion(t *testing.T) {
@@ -42,4 +46,22 @@ func TestParseConsentString(t *testing.T) {
 		t.Fail()
 	}
 	equal(t, 2, v2.CmpVersion)
+}
+
+func TestValidateConsentString(t *testing.T) {
+	err := Validate(csv1)
+	equal(t, nil, err)
+
+	err = Validate(csv2)
+	equal(t, nil, err)
+
+	err = Validate(invalidVersionCS)
+	equal(t, ErrUnsupported, err)
+
+	err = Validate(nonB64CS)
+	_, isBase64Error := err.(base64.CorruptInputError)
+	equal(t, true, isBase64Error)
+
+	err = Validate(truncatedCS)
+	equal(t, ErrUnexpectedEnd, err)
 }

--- a/consentv1.go
+++ b/consentv1.go
@@ -40,6 +40,8 @@ type ConsentV1 struct {
 	encodingType encodingType
 
 	Vendors map[int]bool
+
+	validateOnlyMode bool
 }
 
 func (c *ConsentV1) Version() byte {
@@ -249,7 +251,9 @@ func (c *ConsentV1) ParseRaw(binary []byte) error {
 			if by, ok := b.ReadByte(1); !ok {
 				return ErrUnexpectedEnd
 			} else if by == 1 {
-				c.Vendors[i] = true
+				if !c.validateOnlyMode {
+					c.Vendors[i] = true
+				}
 			}
 		}
 	case rangeType:
@@ -262,7 +266,9 @@ func (c *ConsentV1) ParseRaw(binary []byte) error {
 			defCons = true
 
 			for i := 1; i <= int(c.MaxVendorID); i++ {
-				c.Vendors[i] = true
+				if !c.validateOnlyMode {
+					c.Vendors[i] = true
+				}
 			}
 		}
 
@@ -294,7 +300,9 @@ func (c *ConsentV1) ParseRaw(binary []byte) error {
 					if defCons {
 						delete(c.Vendors, int(j))
 					} else {
-						c.Vendors[int(j)] = true
+						if !c.validateOnlyMode {
+							c.Vendors[int(j)] = true
+						}
 					}
 				}
 			}
@@ -319,4 +327,11 @@ func (c *ConsentV1) Parse(data string) error {
 func ParseV1(data string) (*ConsentV1, error) {
 	c := new(ConsentV1)
 	return c, c.Parse(data)
+}
+
+// Validate validates base64 encoded consent string
+func ValidateV1(data string) error {
+	c := new(ConsentV1)
+	c.validateOnlyMode = true
+	return c.Parse(data)
 }


### PR DESCRIPTION
Building all the vendor maps when parsing the consent data structure is somewhat expensive and it's unnecessary in use cases where you're just parsing the string in order to validate it, so this change adds functions to skip the construction of those maps.
Benchmarking the validation mode against the regular parser on a typical string in our system gives the following results:
```
pkg: github.com/pubnative/consent
BenchmarkParseConsent-4      	   13120	     89173 ns/op	   41662 B/op	      92 allocs/op
BenchmarkValidateConsent-4   	   81999	     14445 ns/op	     848 B/op	       5 allocs/op
```